### PR TITLE
Refactor transformStats impls for consistency

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -166,7 +166,7 @@ abstract class Flatten extends InfoTransform {
     override def transformStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       val stats1 = super.transformStats(stats, exprOwner)
       if (currentOwner.isPackageClass) {
-        val lifted = liftedDefs(currentOwner).toList
+        val lifted = liftedDefs.remove(currentOwner).toList.flatten
         stats1 ::: lifted
       }
       else stats1

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -539,12 +539,11 @@ abstract class LambdaLift extends InfoTransform {
     override def transformStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       def addLifted(stat: Tree): Tree = stat match {
         case ClassDef(_, _, _, _) =>
-          val lifted = liftedDefs get stat.symbol match {
+          val lifted = liftedDefs remove stat.symbol match {
             case Some(xs) => xs reverseMap addLifted
             case _        => log("unexpectedly no lifted defs for " + stat.symbol) ; Nil
           }
-          try deriveClassDef(stat)(impl => deriveTemplate(impl)(_ ::: lifted))
-          finally liftedDefs -= stat.symbol
+          deriveClassDef(stat)(impl => deriveTemplate(impl)(_ ::: lifted))
 
         case DefDef(_, _, _, _, _, Block(Nil, expr)) if !stat.symbol.isConstructor =>
           deriveDefDef(stat)(_ => expr)


### PR DESCRIPTION
Uses the same idiom in `Flatten` and `LambdaLift` as is established
in `Extender` and (recently) `Delambdafy`. This avoids any possibility
of adding a member to a package twice, as used to happen in SI-9097.
